### PR TITLE
PR-AZR-0009-TRF: Azure AKS cluster pool profile should have minimum 3 or more nodes

### DIFF
--- a/examples/kubernetes/monitoring-log-analytics/main.tf
+++ b/examples/kubernetes/monitoring-log-analytics/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 
   default_node_pool {
     name       = "default"
-    node_count = 1
+    node_count = 3
     vm_size    = "Standard_DS2_v2"
   }
 


### PR DESCRIPTION
**Violation Id:** PR-AZR-0009-TRF 

 **Violation Description:** 

 Ensure your AKS cluster pool profile contains minimum 3 or more nodes. This is recommended for a more resilient cluster. (Clusters smaller than 3 may experience downtime during upgrades.)<br><br>This policy checks the size of your cluster pool profiles and alerts if there are fewer than 3 nodes. 

 **How to Fix:** 

 In 'azurerm_kubernetes_cluster' resource, set node_count = 3 under 'default_node_pool' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#node_count' target='_blank'>here</a> for details.