### PR TITLE
Fixed PR-AZR-TRF-AKS-001: Azure AKS cluster CNI networking should be enabled

### DIFF
--- a/examples/kubernetes/public-ip/main.tf
+++ b/examples/kubernetes/public-ip/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 
   network_profile {
-    network_plugin    = "kubenet"
+    network_plugin    = "azure"
     load_balancer_sku = "Standard"
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AKS-001 

 **Violation Description:** 

 Azure CNI provides the following features over kubenet networking:<br><br>- Every pod in the cluster is assigned an IP address in the virtual network. The pods can directly communicate with other pods in the cluster, and other nodes in the virtual network.<br>- Pods in a subnet that have service endpoints enabled can securely connect to Azure services, such as Azure Storage and SQL DB.<br>- You can create user-defined routes (UDR) to route traffic from pods to a Network Virtual Appliance.<br>- Support for Network Policies securing communication between pods.<br><br>This policy checks your AKS cluster for the Azure CNI network plugin and generates an alert if not found. 

 **How to Fix:** 

 In 'azurerm_kubernetes_cluster' resource, set network_plugin = 'azure' under 'network_profile' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#network_policy' target='_blank'>here</a> for details.